### PR TITLE
domelementtype switched to ESModules

### DIFF
--- a/src/jsx-serializer.ts
+++ b/src/jsx-serializer.ts
@@ -1,7 +1,7 @@
 /*
  * Module dependencies
  */
-import ElementType from "domelementtype";
+import { ElementType } from "domelementtype";
 import type { Node, NodeWithChildren, Element, DataNode } from "domhandler";
 import { encodeXML } from "entities";
 import { camelCase } from "lodash-es";


### PR DESCRIPTION
Thought I'd try to help out, domelementtype switched to ESModules and it's breaking this library.