### PR TITLE
Ignore generated HTML in GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+htmls/** linguist-generated


### PR DESCRIPTION
This should make the project be classified as TypeScript instead of HTML, so when people do searching using language filters, this project will show up correctly.

Ref: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github